### PR TITLE
Make the bindings compile with -vet and -strict-style compiler flags

### DIFF
--- a/color.odin
+++ b/color.odin
@@ -578,9 +578,9 @@ make_color :: proc "contextless" (hex_code: Hex_Color) -> Color
     hex_code := int(hex_code)
 	color.r = cast(f32)((hex_code >> 16) & 0xFF) / 255
 	color.g = cast(f32)((hex_code >> 8) & 0xFF) / 255
-	color.b = cast(f32)(hex_code & 0xFF) / 255;
-	color.a = 1;
-	return color;
+	color.b = cast(f32)(hex_code & 0xFF) / 255
+	color.a = 1
+	return color
 }
 
 // Make a color from a hex code and alpha
@@ -590,7 +590,7 @@ make_color_alpha :: proc "contextless" (hex_code: Hex_Color, alpha: f32) -> Colo
     hex_code := int(hex_code)
 	color.r = cast(f32)((hex_code >> 16) & 0xFF) / 255
 	color.g = cast(f32)((hex_code >> 8) & 0xFF) / 255
-	color.b = cast(f32)(hex_code & 0xFF) / 255;
-	color.a = alpha;
-	return color;
+	color.b = cast(f32)(hex_code & 0xFF) / 255
+	color.a = alpha
+	return color
 }

--- a/distance.odin
+++ b/distance.odin
@@ -48,7 +48,7 @@ Distance_Output :: struct
 	point_a, ///< closest point on shapeA
 	point_b: Vec2, ///< closest point on shapeB
 	distance: f32,
-	iterations: i32 ///< number of GJK iterations used
+	iterations: i32, ///< number of GJK iterations used
 }
 
 // Input parameters for b2ShapeCast
@@ -86,7 +86,7 @@ TOI_Input :: struct
 	sweep_b: Sweep,
 
 	// defines sweep interval [0, tMax]
-	t_max: f32
+	t_max: f32,
 }
 
 // Describes the TOI output
@@ -96,7 +96,7 @@ TOI_State :: enum i32
 	Failed,
 	Overlapped,
 	Hit,
-	Separated
+	Separated,
 }
 
 // Output parameters for time_of_impact.

--- a/dynamic_tree.odin
+++ b/dynamic_tree.odin
@@ -77,11 +77,11 @@ Tree_Shape_Cast_Callback_Fcn :: #type proc "c" (input: ^Shape_Cast_Input, proxy_
 // - return the proxy user data or 0 if the id is invalid
 dynamic_tree_get_user_data :: #force_inline proc(tree: ^Dynamic_Tree, proxy_id: i32) -> i32
 {
-	return tree.nodes[proxy_id].user_data;
+	return tree.nodes[proxy_id].user_data
 }
 
 // Get the AABB of a proxy
 dynamic_tree_get_aabb :: #force_inline proc(tree: ^Dynamic_Tree, proxy_id: i32) -> AABB
 {
-	return tree.nodes[proxy_id].aabb;
+	return tree.nodes[proxy_id].aabb
 }

--- a/geometry.odin
+++ b/geometry.odin
@@ -74,7 +74,7 @@ Polygon :: struct
 // A line segment with two-sided collision.
 Segment :: struct
 {
-	point1, point2: Vec2
+	point1, point2: Vec2,
 }
 
 // A smooth line segment with one-sided collision. Only collides on the right side.

--- a/types.odin
+++ b/types.odin
@@ -135,7 +135,7 @@ Body_Def :: struct
 	is_bullet,
 
 	// Does this body start out enabled?
-	is_enabled: bool
+	is_enabled: bool,
 }
 
 // This holds contact filtering data.


### PR DESCRIPTION
Fix for bindings not compiling with -vet and -strict-style enabled

Thanks for these nice bindings! I used them in this 1 hour try-box2d-jam live stream: https://www.youtube.com/watch?v=LYW7jdwEnaI
